### PR TITLE
Fix missing CRLF on request packet

### DIFF
--- a/src/main/java/de/w3is/jdial/protocol/MSearchImpl.java
+++ b/src/main/java/de/w3is/jdial/protocol/MSearchImpl.java
@@ -56,7 +56,7 @@ class MSearchImpl implements MSearch {
                 "MAN: \"ssdp:discover\"\r\n" +
                 "MX: " + responseDelay + "\r\n" +
                 SEARCH_TARGET_HEADER + ": " + SEARCH_TARGET_HEADER_VALUE + "\r\n" +
-                "USER-AGENT: OS/version product/version\r\n";
+                "USER-AGENT: OS/version product/version\r\n\r\n";
 
         this.socketTimeoutMs = socketTimeoutMs;
     }


### PR DESCRIPTION
There should be an extra CRLF to mark the end of HTTP headers.

The Chromecast I tested with does not respond unless this is given.