### PR TITLE
Set default M-SEARCH max response delay to 1 second

### DIFF
--- a/src/main/java/de/w3is/jdial/protocol/ProtocolFactoryImpl.java
+++ b/src/main/java/de/w3is/jdial/protocol/ProtocolFactoryImpl.java
@@ -31,7 +31,7 @@ public class ProtocolFactoryImpl implements ProtocolFactory {
     private int httpClientReadTimeoutMs = 1500;
     private int httpClientConnectionTimeoutMs = 1500;
     private int socketTimeoutMs = 1500;
-    private int mSearchResponseDelay = 0;
+    private int mSearchResponseDelay = 1;
 
     public ProtocolFactoryImpl(boolean legacyCompatibility) {
 


### PR DESCRIPTION
The spec states the following (from https://openconnectivity.org/upnp-specs/UPnP-arch-DeviceArchitecture-v2.0-20200417.pdf)

> MX
Required. Field value contains maximum wait time in seconds. shall be greater than or equal to 1 and should
be less than 5 inclusive. Device responses should be delayed a random duration between 0 and this many
seconds to balance load for the control point when it processes responses.

So 0 is not valid. It appears that chromecasts will not respond to a delay of 0.